### PR TITLE
Fix typo of n+1 in Lagrange basis

### DIFF
--- a/src/05_Interpolation.jl
+++ b/src/05_Interpolation.jl
@@ -305,7 +305,7 @@ Both a more practical as well as a numerically more stable way to find
 	(\textcolor{red}{x_i} - x_{i-1})
 	(\textcolor{red}{x_i} - x_{i+1})
 	\cdots
-	(\textcolor{red}{x_i} - x_{n})
+	(\textcolor{red}{x_i} - x_{n+1})
 		   }
     \end{aligned}
     ```


### PR DESCRIPTION
A student found out that the `+1` was missing in the denominator in
![image](https://github.com/user-attachments/assets/f7ba3647-3118-4f73-80eb-ab8e52e508b4)
(the image is the fixed version)